### PR TITLE
Highlight insert mode canvas and centralize shared colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import StatusBar from './components/StatusBar/StatusBar';
 import Terminal from './components/Terminal/Terminal';
 import { useCommandConsole } from './hooks/useCommandConsole';
 import { useEngine } from './hooks/useEngine';
+import { FALLBACK_PALETTE } from './theme/colors';
 import './App.css';
 
 const STORAGE_KEY = 'vpix.document.v1';
@@ -20,7 +21,7 @@ export default function App() {
   const paletteService = useMemo(() => new PaletteService(), []);
   const engineFactory = useCallback(() => {
     const pico = paletteService.getPaletteBySlug('pico-8');
-    const colors = pico ? pico.colors : ['#000', '#fff'];
+    const colors = pico ? pico.colors : Array.from(FALLBACK_PALETTE);
     return new VPixEngine({ width: 32, height: 24, palette: colors });
   }, [paletteService]);
 

--- a/src/components/CanvasGrid/CanvasGrid.css
+++ b/src/components/CanvasGrid/CanvasGrid.css
@@ -4,6 +4,10 @@
   align-items: center;
   justify-content: center;
   background: #0b0b0b;
+  box-sizing: border-box;
+}
+.canvas-grid.insert-mode {
+  border: 2px solid var(--color-accent);
 }
 .canvas-layer-stack {
   position: relative;

--- a/src/components/CanvasGrid/CanvasGrid.tsx
+++ b/src/components/CanvasGrid/CanvasGrid.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 
 import type VPixEngine from '../../../core/engine';
+import { MODES } from '../../../core/engine';
+import { COLOR_THEME } from '../../theme/colors';
 import './CanvasGrid.css';
 
 type Props = {
@@ -16,6 +18,9 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
   const panX = pan?.x ?? 0;
   const panY = pan?.y ?? 0;
   const cellSize = useMemo(() => Math.max(1, Math.floor(16 * (zoom || 1))), [zoom]);
+  const isInsertMode = engine.mode === MODES.INSERT;
+  const gridClassName = isInsertMode ? 'canvas-grid insert-mode' : 'canvas-grid';
+  const { canvasBackground, gridLine, accent, cursorHighlight } = COLOR_THEME;
 
   useEffect(() => {
     if (typeof navigator !== 'undefined' && /jsdom/i.test((navigator as any).userAgent || '')) return;
@@ -41,7 +46,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
       const vx = Math.floor(offsetX + x * cell);
       const vy = Math.floor(offsetY + y * cell);
       if (vx + cell < 0 || vy + cell < 0 || vx >= viewW || vy >= viewH) return;
-      ctx.fillStyle = '#0b0b0b';
+      ctx.fillStyle = canvasBackground;
       ctx.fillRect(vx, vy, cell, cell);
       const colorIndex = engine.grid[y][x];
       if (colorIndex != null) {
@@ -54,7 +59,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     };
 
     // Always full redraw - simpler and bug-free
-    ctx.fillStyle = '#0b0b0b';
+    ctx.fillStyle = canvasBackground;
     ctx.fillRect(0, 0, viewW, viewH);
     for (let y = 0; y < engine.height; y++) {
       for (let x = 0; x < engine.width; x++) drawCell(x, y);
@@ -93,7 +98,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     const clipBottom = Math.min(viewH, Math.ceil(gridBottom));
 
     if (clipRight > clipLeft && clipBottom > clipTop) {
-      ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+      ctx.strokeStyle = gridLine;
       ctx.lineWidth = 1;
       for (let x = 0; x <= engine.width; x++) {
         const vx = Math.floor(offsetX + x * cell) + 0.5;
@@ -127,7 +132,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
       const sw = (x2 - x1 + 1) * cell;
       const sh = (y2 - y1 + 1) * cell;
       if (sx + sw >= 0 && sy + sh >= 0 && sx <= viewW && sy <= viewH) {
-        ctx.strokeStyle = '#00e1ff';
+        ctx.strokeStyle = accent;
         ctx.lineWidth = 2;
         ctx.strokeRect(Math.floor(sx) + 0.5, Math.floor(sy) + 0.5, Math.floor(sw), Math.floor(sh));
       }
@@ -136,14 +141,14 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     const cx = offsetX + engine.cursor.x * cell;
     const cy = offsetY + engine.cursor.y * cell;
     if (cx + cell >= 0 && cy + cell >= 0 && cx <= viewW && cy <= viewH) {
-      ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+      ctx.strokeStyle = cursorHighlight;
       ctx.lineWidth = 1;
       ctx.strokeRect(Math.floor(cx) + 0.5, Math.floor(cy) + 0.5, Math.max(1, cell - 1), Math.max(1, cell - 1));
     }
   }, [cellSize, engine, frame, panX, panY]);
 
   return (
-    <div className="canvas-grid">
+    <div className={gridClassName}>
       <div className="canvas-layer-stack">
         <canvas ref={baseRef} className="canvas-base" width={800} height={480} />
         <canvas ref={overlayRef} className="canvas-overlay" width={800} height={480} />

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import type VPixEngine from '../../../core/engine';
+import { COLOR_THEME } from '../../theme/colors';
 import './MiniMap.css';
 
 type Props = {
@@ -14,6 +15,7 @@ type Props = {
 
 export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, frame = 0 }: Props) {
   const ref = useRef<HTMLCanvasElement | null>(null);
+  const { canvasBackground, accent } = COLOR_THEME;
   useEffect(() => {
     // Skip drawing in jsdom test environment (no canvas impl)
     if (typeof navigator !== 'undefined' && /jsdom/i.test((navigator as any).userAgent || '')) return;
@@ -32,7 +34,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
 
     const drawCell = (x, y) => {
       const px = x * cell, py = y * cell;
-      ctx.fillStyle = '#0b0b0b';
+      ctx.fillStyle = canvasBackground;
       ctx.fillRect(px, py, cell, cell);
       const colorIndex = engine.grid[y][x];
       if (colorIndex != null) {
@@ -42,7 +44,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
     };
 
     // Always full redraw
-    ctx.fillStyle = '#0b0b0b';
+    ctx.fillStyle = canvasBackground;
     ctx.fillRect(0, 0, w, h);
     for (let y = 0; y < engine.height; y++) {
       for (let x = 0; x < engine.width; x++) drawCell(x, y);
@@ -55,7 +57,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
     const ry = Math.max(0, Math.min(engine.height, (pan?.y || 0))) * cell;
     const rw = Math.min(engine.width, visWcells) * cell;
     const rh = Math.min(engine.height, visHcells) * cell;
-    ctx.strokeStyle = '#00e1ff';
+    ctx.strokeStyle = accent;
     ctx.lineWidth = 2;
     ctx.strokeRect(rx + 0.5, ry + 0.5, rw, rh);
   }, [engine, pan, zoom, viewW, viewH, frame]);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
-:root { color-scheme: dark; }
+:root {
+  color-scheme: dark;
+  --color-background: #0b0b0b;
+  --color-accent: #00e1ff;
+}
 html, body, #root { height: 100%; margin: 0; }
-body { background: #0b0b0b; }
+body { background: var(--color-background); }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,8 @@
+export const COLOR_THEME = {
+  canvasBackground: '#0b0b0b',
+  accent: '#00e1ff',
+  gridLine: 'rgba(255, 255, 255, 0.05)',
+  cursorHighlight: 'rgba(255, 255, 255, 0.9)',
+} as const;
+
+export const FALLBACK_PALETTE = ['#000000', '#ffffff'] as const;


### PR DESCRIPTION
## Summary
- add an insert-mode modifier to the canvas grid so insert mode is visually indicated with a border
- centralize shared drawing colors and the fallback palette in a theme module reused by the canvas and minimap
- expose core theme colors via CSS variables for future reuse

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e42555b4f483249720f9f601c15bd4