### PR TITLE
Add ellipse drawing tools to visual mode selections

### DIFF
--- a/core/commands/selection.ts
+++ b/core/commands/selection.ts
@@ -118,6 +118,26 @@ export const selectionCommands: CommandDefinition[] = [
     patterns: [{ pattern: 'selection stroke', help: 'selection stroke' }],
   },
   {
+    id: 'selection.stroke-circle',
+    summary: 'Stroke selection circle',
+    handler: ({ engine }) => {
+      engine.strokeCircleSelection();
+      engine.exitVisual();
+      engine.clearPrefix();
+    },
+    patterns: [{ pattern: 'selection stroke-circle', help: 'selection stroke-circle' }],
+  },
+  {
+    id: 'selection.fill-circle',
+    summary: 'Fill selection circle',
+    handler: ({ engine }) => {
+      engine.fillCircleSelection();
+      engine.exitVisual();
+      engine.clearPrefix();
+    },
+    patterns: [{ pattern: 'selection fill-circle', help: 'selection fill-circle' }],
+  },
+  {
     id: 'selection.draw-line',
     summary: 'Draw line between selection anchor and cursor',
     handler: ({ engine }) => {

--- a/core/engine/index.ts
+++ b/core/engine/index.ts
@@ -5,6 +5,7 @@ import { floodFill as floodFillTool } from '../tools/flood-fill';
 import { fillRect as fillRectTool } from '../tools/fill-rect';
 import { drawLine as drawLineTool } from '../tools/line';
 import { strokeRect as strokeRectTool } from '../tools/stroke-rect';
+import { fillEllipse as fillEllipseTool, strokeEllipse as strokeEllipseTool } from '../tools/circle';
 import type { ToolOperation } from '../tools/types';
 import { ClipboardBuffer } from './clipboard';
 import { EngineEvents } from './events';
@@ -480,6 +481,20 @@ export default class VPixEngine {
     if (!rect) return;
     const operations = strokeRectTool(rect, colorIndex, (x, y) => this.gridState.getCell(x, y));
     this.applyToolOperations('rect', operations);
+  }
+
+  strokeCircleSelection(colorIndex: number = this._currentColorIndex) {
+    const rect = this.selection.rect;
+    if (!rect) return;
+    const operations = strokeEllipseTool(rect, colorIndex, (x, y) => this.gridState.getCell(x, y));
+    this.applyToolOperations('ellipse-stroke', operations);
+  }
+
+  fillCircleSelection(colorIndex: number = this._currentColorIndex) {
+    const rect = this.selection.rect;
+    if (!rect) return;
+    const operations = fillEllipseTool(rect, colorIndex, (x, y) => this.gridState.getCell(x, y));
+    this.applyToolOperations('ellipse-fill', operations);
   }
 
   drawLine(a: Point | null, b: Point | null, colorIndex: number = this._currentColorIndex) {

--- a/core/keybindings.ts
+++ b/core/keybindings.ts
@@ -382,6 +382,8 @@ export const KEYBINDINGS: KeyBinding[] = [
   { scope: 'visual', key: 'M', command: 'selection.move-to-cursor', description: 'Move selection to cursor' },
   { scope: 'visual', key: 'F', command: 'selection.fill', description: 'Fill selection' },
   { scope: 'visual', key: 'R', command: 'selection.stroke-rect', description: 'Stroke selection rectangle' },
+  { scope: 'visual', key: 'C', command: 'selection.stroke-circle', description: 'Stroke selection circle' },
+  { scope: 'visual', key: 'O', command: 'selection.fill-circle', description: 'Fill selection circle' },
   { scope: 'visual', key: 'L', command: 'selection.draw-line', description: 'Draw line across selection' },
   { scope: 'visual', key: 'f', command: 'selection.flood-fill', description: 'Flood fill selection' },
 ];

--- a/core/tools/circle.ts
+++ b/core/tools/circle.ts
@@ -1,0 +1,86 @@
+import type { GridValue, Point, ReadCell, Rect, ToolOperation } from './types';
+
+function normalizeRect(rect: Rect): Rect {
+  const x1 = Math.min(rect.x1, rect.x2);
+  const y1 = Math.min(rect.y1, rect.y2);
+  const x2 = Math.max(rect.x1, rect.x2);
+  const y2 = Math.max(rect.y1, rect.y2);
+  return { x1, y1, x2, y2 };
+}
+
+function isInsideEllipse(x: number, y: number, cx: number, cy: number, rx: number, ry: number) {
+  const dx = x - cx;
+  const dy = y - cy;
+
+  if (rx === 0 && ry === 0) {
+    return Math.abs(dx) <= 0.5 && Math.abs(dy) <= 0.5;
+  }
+
+  if (rx === 0) {
+    return Math.abs(dx) <= 0.5 && Math.abs(dy) <= ry + 0.5;
+  }
+
+  if (ry === 0) {
+    return Math.abs(dy) <= 0.5 && Math.abs(dx) <= rx + 0.5;
+  }
+
+  const normX = dx / rx;
+  const normY = dy / ry;
+  return normX * normX + normY * normY <= 1 + 1e-6;
+}
+
+function collectEllipsePoints(rect: Rect): { points: Point[]; lookup: Set<string> } {
+  const { x1, y1, x2, y2 } = normalizeRect(rect);
+  const cx = (x1 + x2) / 2;
+  const cy = (y1 + y2) / 2;
+  const rx = (x2 - x1) / 2;
+  const ry = (y2 - y1) / 2;
+
+  const points: Point[] = [];
+  const lookup = new Set<string>();
+
+  for (let y = y1; y <= y2; y += 1) {
+    for (let x = x1; x <= x2; x += 1) {
+      if (!isInsideEllipse(x, y, cx, cy, rx, ry)) continue;
+      const key = `${x}:${y}`;
+      if (lookup.has(key)) continue;
+      lookup.add(key);
+      points.push({ x, y });
+    }
+  }
+
+  return { points, lookup };
+}
+
+export function fillEllipse(rect: Rect, value: GridValue, readCell: ReadCell): ToolOperation[] {
+  const { points } = collectEllipsePoints(rect);
+  const ops: ToolOperation[] = [];
+
+  for (const point of points) {
+    if (readCell(point.x, point.y) === value) continue;
+    ops.push({ x: point.x, y: point.y, value });
+  }
+
+  return ops;
+}
+
+function isInterior(point: Point, lookup: Set<string>) {
+  const left = `${point.x - 1}:${point.y}`;
+  const right = `${point.x + 1}:${point.y}`;
+  const up = `${point.x}:${point.y - 1}`;
+  const down = `${point.x}:${point.y + 1}`;
+  return lookup.has(left) && lookup.has(right) && lookup.has(up) && lookup.has(down);
+}
+
+export function strokeEllipse(rect: Rect, value: GridValue, readCell: ReadCell): ToolOperation[] {
+  const { points, lookup } = collectEllipsePoints(rect);
+  const ops: ToolOperation[] = [];
+
+  for (const point of points) {
+    if (isInterior(point, lookup)) continue;
+    if (readCell(point.x, point.y) === value) continue;
+    ops.push({ x: point.x, y: point.y, value });
+  }
+
+  return ops;
+}

--- a/test/tools.spec.ts
+++ b/test/tools.spec.ts
@@ -5,6 +5,7 @@ import { floodFill } from '../core/tools/flood-fill';
 import { fillRect } from '../core/tools/fill-rect';
 import { drawLine } from '../core/tools/line';
 import { strokeRect } from '../core/tools/stroke-rect';
+import { fillEllipse, strokeEllipse } from '../core/tools/circle';
 
 const makeReader = (grid: Array<Array<number | null>>) => (x: number, y: number) => grid[y]?.[x] ?? null;
 
@@ -45,6 +46,24 @@ describe('tool algorithms', () => {
     for (let i = 0; i < ops.length; i += 1) {
       assert.deepEqual(ops[i], { x: i, y: i, value: 3 });
     }
+  });
+
+  it('fillEllipse returns the full set of ellipse cells', () => {
+    const grid = Array.from({ length: 5 }, () => Array(5).fill(null));
+    const ops = fillEllipse({ x1: 0, y1: 0, x2: 4, y2: 4 }, 2, makeReader(grid));
+    assert.ok(ops.length > 0);
+    assert.ok(ops.some((op) => op.x === 2 && op.y === 2));
+    assert.ok(ops.some((op) => op.x === 0 && op.y === 2));
+  });
+
+  it('strokeEllipse returns only border cells', () => {
+    const grid = Array.from({ length: 7 }, () => Array(7).fill(null));
+    const ops = strokeEllipse({ x1: 0, y1: 0, x2: 6, y2: 6 }, 1, makeReader(grid));
+    const keySet = new Set(ops.map((op) => `${op.x}:${op.y}`));
+    assert.equal(keySet.size, ops.length);
+    assert.ok(ops.some((op) => op.x === 0 && op.y === 3));
+    assert.ok(ops.some((op) => op.x === 3 && op.y === 0));
+    assert.ok(!keySet.has('3:3'));
   });
 
   it('floodFill respects bounds and target value', () => {

--- a/test/visual.spec.ts
+++ b/test/visual.spec.ts
@@ -52,6 +52,29 @@ describe('Visual mode operations', () => {
     assert.ok(true);
   });
 
+  it('stroke and fill circle selections', () => {
+    const pico = getPaletteByName('pico-8')!;
+    const eng = new VPixEngine({ width: 7, height: 7, palette: pico.colors });
+    eng.handleKey({ key: 'v' });
+    for (const key of ['l', 'l', 'l', 'l', 'j', 'j', 'j', 'j']) {
+      eng.handleKey({ key });
+    }
+    eng.handleKey({ key: 'C' });
+    assert.equal(eng.mode, MODES.NORMAL);
+    assert.ok(eng.grid[0][2] != null);
+    assert.ok(eng.grid[2][0] != null);
+    assert.equal(eng.grid[2][2], null);
+
+    eng.cursor = { x: 0, y: 0 };
+    eng.handleKey({ key: 'v' });
+    for (const key of ['l', 'l', 'l', 'l', 'j', 'j', 'j', 'j']) {
+      eng.handleKey({ key });
+    }
+    eng.handleKey({ key: 'O' });
+    assert.equal(eng.mode, MODES.NORMAL);
+    assert.ok(eng.grid[2][2] != null);
+  });
+
   it('transparent paste and rotations and move selection', () => {
     const pico = getPaletteByName('pico-8')!;
     const eng = new VPixEngine({ width: 5, height: 5, palette: pico.colors });


### PR DESCRIPTION
## Summary
- add tooling to generate ellipse fill and stroke operations for selections
- expose circle fill and stroke commands with visual mode keybindings
- expand visual mode and tool tests to cover the new shapes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43249f78c8324bfe63cfb52498da7