### PR TITLE
Remove insert mode and update bindings

### DIFF
--- a/core/commands/mode.ts
+++ b/core/commands/mode.ts
@@ -54,26 +54,19 @@ const applyOperator = (
       eng.cursor.x = repeatCursor.x;
       eng.cursor.y = repeatCursor.y;
       const changedAgain = eng.deleteSegment(repeatSegment);
-      if (op === 'change') {
-        eng.setMode(MODES.INSERT);
-      } else if (!changedAgain) {
+      if (!changedAgain) {
         eng.emit();
       }
     });
   };
 
   const changed = applyDelete();
-  if (op === 'change') {
-    engine.setMode(MODES.INSERT);
-  }
 
   if (changed) {
     recordRepeat();
   } else {
     engine.recordLastAction(null);
-    if (op !== 'change') {
-      engine.emit();
-    }
+    engine.emit();
   }
 };
 
@@ -89,18 +82,6 @@ const applyPendingOperator = (engine: CommandContext['engine'], motion: MotionKi
 };
 
 export const modeCommands: CommandDefinition[] = [
-  {
-    id: 'mode.insert',
-    summary: 'Switch to insert mode',
-    handler: ({ engine }) => {
-      engine.setMode(MODES.INSERT);
-      engine.clearPrefix();
-    },
-    patterns: [
-      { pattern: 'mode insert', help: 'mode insert' },
-      { pattern: 'insert', help: 'insert' },
-    ],
-  },
   {
     id: 'mode.normal',
     summary: 'Switch to normal mode',

--- a/core/engine/index.ts
+++ b/core/engine/index.ts
@@ -242,7 +242,6 @@ export default class VPixEngine {
       const stepMoved = this.cursorManager.moveBy(dx, dy, this.width, this.height);
       if (!stepMoved) continue;
       moved = true;
-      if (this.modeManager.current === MODES.INSERT) this.paint();
     }
     if (moved) {
       this.emit();

--- a/core/engine/state.ts
+++ b/core/engine/state.ts
@@ -27,7 +27,7 @@ export class ModeManager {
   }
 
   set(mode: Mode) {
-    if (mode !== MODES.NORMAL && mode !== MODES.INSERT && mode !== MODES.VISUAL) return false;
+    if (mode !== MODES.NORMAL && mode !== MODES.VISUAL) return false;
     if (this.value === mode) return false;
     this.value = mode;
     return true;

--- a/core/engine/types.ts
+++ b/core/engine/types.ts
@@ -1,6 +1,5 @@
 export const MODES = {
   NORMAL: 'normal',
-  INSERT: 'insert',
   VISUAL: 'visual',
 } as const;
 

--- a/core/keybindings.ts
+++ b/core/keybindings.ts
@@ -1,6 +1,6 @@
 import type VPixEngine from './engine';
 
-export type BindingScope = 'global' | 'normal' | 'insert' | 'visual';
+export type BindingScope = 'global' | 'normal' | 'visual';
 export type BindingCondition = 'always' | 'no-prefix' | 'prefix:any' | 'prefix:g' | 'prefix:r';
 
 export type BindingContext = {
@@ -87,13 +87,6 @@ export const KEYBINDINGS: KeyBinding[] = [
     when: 'no-prefix',
     args: ({ count }) => ({ count: clampCount(count) }),
     description: 'Move to end of run',
-  },
-  {
-    scope: 'normal',
-    key: 'i',
-    command: 'mode.insert',
-    when: 'no-prefix',
-    description: 'Switch to insert mode',
   },
   {
     scope: 'normal',
@@ -286,55 +279,6 @@ export const KEYBINDINGS: KeyBinding[] = [
     when: 'prefix:r',
     args: ({ event }) => ({ index: parseInt(event.key, 10) }),
     description: 'Paint using palette color by index',
-  },
-
-  // Insert mode bindings
-  {
-    scope: 'insert',
-    key: 'Escape',
-    command: 'mode.normal',
-    description: 'Return to normal mode',
-  },
-  {
-    scope: 'insert',
-    key: 'h',
-    command: 'cursor.move-left',
-    args: ({ count }) => ({ count: clampCount(count) }),
-    description: 'Move cursor left',
-  },
-  {
-    scope: 'insert',
-    key: 'j',
-    command: 'cursor.move-down',
-    args: ({ count }) => ({ count: clampCount(count) }),
-    description: 'Move cursor down',
-  },
-  {
-    scope: 'insert',
-    key: 'k',
-    command: 'cursor.move-up',
-    args: ({ count }) => ({ count: clampCount(count) }),
-    description: 'Move cursor up',
-  },
-  {
-    scope: 'insert',
-    key: 'l',
-    command: 'cursor.move-right',
-    args: ({ count }) => ({ count: clampCount(count) }),
-    description: 'Move cursor right',
-  },
-  {
-    scope: 'insert',
-    key: ' ',
-    command: 'paint.apply',
-    description: 'Paint current cell',
-  },
-  {
-    scope: 'insert',
-    key: 'Backspace',
-    command: 'paint.erase',
-    args: () => ({ count: 1 }),
-    description: 'Erase current cell',
   },
 
   // Visual mode bindings

--- a/core/keymap.ts
+++ b/core/keymap.ts
@@ -24,7 +24,7 @@ function buildLookup(bindings: KeyBinding[]): BindingLookup {
       acc[binding.scope].push(binding);
       return acc;
     },
-    { global: [], normal: [], insert: [], visual: [] } as BindingLookup,
+    { global: [], normal: [], visual: [] } as BindingLookup,
   );
 }
 
@@ -107,7 +107,6 @@ function runBinding(
 
 function scopeForMode(mode: number): BindingScope {
   if (mode === MODES.NORMAL) return 'normal';
-  if (mode === MODES.INSERT) return 'insert';
   return 'visual';
 }
 

--- a/src/__tests__/app.spec.tsx
+++ b/src/__tests__/app.spec.tsx
@@ -141,7 +141,7 @@ describe('App keyboard flows', () => {
     await userEvent.keyboard(' ');
     await userEvent.keyboard('l ');
     await userEvent.keyboard('0cw');
-    expect(engine.mode).toBe('insert');
+    expect(engine.mode).toBe('normal');
     expect(engine.grid[0][0]).toBeNull();
   });
 

--- a/src/components/CanvasGrid/CanvasGrid.css
+++ b/src/components/CanvasGrid/CanvasGrid.css
@@ -6,9 +6,6 @@
   background: #0b0b0b;
   box-sizing: border-box;
 }
-.canvas-grid.insert-mode {
-  border: 2px solid var(--color-accent);
-}
 .canvas-layer-stack {
   position: relative;
   line-height: 0;

--- a/src/components/CanvasGrid/CanvasGrid.tsx
+++ b/src/components/CanvasGrid/CanvasGrid.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 
 import type VPixEngine from '../../../core/engine';
-import { MODES } from '../../../core/engine';
 import { COLOR_THEME } from '../../theme/colors';
 import './CanvasGrid.css';
 
@@ -18,8 +17,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
   const panX = pan?.x ?? 0;
   const panY = pan?.y ?? 0;
   const cellSize = useMemo(() => Math.max(1, Math.floor(16 * (zoom || 1))), [zoom]);
-  const isInsertMode = engine.mode === MODES.INSERT;
-  const gridClassName = isInsertMode ? 'canvas-grid insert-mode' : 'canvas-grid';
+  const gridClassName = 'canvas-grid';
   const { canvasBackground, gridLine, accent, cursorHighlight } = COLOR_THEME;
 
   useEffect(() => {

--- a/test/engine.spec.ts
+++ b/test/engine.spec.ts
@@ -39,30 +39,11 @@ describe('VPixEngine', () => {
     assert.deepEqual(eng.cursor, { x: 9, y: 0 });
   });
 
-  it('insert mode paints as it moves', () => {
-    const eng = new VPixEngine({ width: 3, height: 1, palette: pico.colors });
-    eng.handleKey({ key: 'i' });
-    assert.equal(eng.mode, MODES.INSERT);
-    eng.paint();
-    eng.handleKey({ key: 'l' });
-    eng.handleKey({ key: 'l' });
-    assert.ok(eng.grid[0][0] != null);
-    assert.ok(eng.grid[0][1] != null);
-    assert.ok(eng.grid[0][2] != null);
-    eng.handleKey({ key: 'Escape' });
-    assert.equal(eng.mode, MODES.NORMAL);
-  });
-
-  it('erases with x in normal mode and Backspace in insert', () => {
+  it('erases with x in normal mode', () => {
     const eng = new VPixEngine({ width: 2, height: 1, palette: pico.colors });
     eng.paint();
     assert.ok(eng.grid[0][0] != null);
     eng.handleKey({ key: 'x' });
-    assert.equal(eng.grid[0][0], null);
-    eng.handleKey({ key: 'i' });
-    eng.paint();
-    assert.ok(eng.grid[0][0] != null);
-    eng.handleKey({ key: 'Backspace' });
     assert.equal(eng.grid[0][0], null);
   });
 
@@ -218,7 +199,6 @@ describe('VPixEngine', () => {
     engChange.handleKey({ key: 'c' });
     engChange.handleKey({ key: 'w' });
     assert.deepEqual(rowChange.slice(0, 4), [null, null, 4, 4]);
-    assert.equal(engChange.mode, MODES.INSERT);
 
     const engDeleteToEnd = new VPixEngine({ width: 4, height: 1, palette: pico.colors });
     const rowEnd = engDeleteToEnd.grid[0];

--- a/test/visual.spec.ts
+++ b/test/visual.spec.ts
@@ -135,7 +135,7 @@ describe('Visual mode operations', () => {
     assert.equal(eng.grid[4][4], null); // outside selection
     assert.equal(eng.grid[4][0], null); // outside selection
 
-    // Move cursor and verify it doesn't paint (not in insert mode)
+    // Move cursor and verify it doesn't paint while moving in normal mode
     eng.cursor = { x: 0, y: 0 };
     eng.move(1, 0); // move right
     assert.equal(eng.grid[0][0], null); // should still be null


### PR DESCRIPTION
## Summary
- remove insert mode support from engine modes, key dispatch, and command bindings
- drop insert-mode UI styling and simplify canvas grid handling
- update unit and integration tests to reflect normal-mode-only behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4b3db000083248255b0e443bfe593