### PR TITLE
Rename grid color theme constant to GRID_THEME

### DIFF
--- a/src/components/CanvasGrid/CanvasGrid.tsx
+++ b/src/components/CanvasGrid/CanvasGrid.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 
 import type VPixEngine from '../../../core/engine';
-import { COLOR_THEME } from '../../theme/colors';
+import { GRID_THEME } from '../../theme/colors';
 import './CanvasGrid.css';
 
 type Props = {
@@ -18,7 +18,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
   const panY = pan?.y ?? 0;
   const cellSize = useMemo(() => Math.max(1, Math.floor(16 * (zoom || 1))), [zoom]);
   const gridClassName = 'canvas-grid';
-  const { canvasBackground, gridLine, accent, cursorHighlight } = COLOR_THEME;
+  const { canvasBackground, gridLine, accent, cursorHighlight } = GRID_THEME;
 
   useEffect(() => {
     if (typeof navigator !== 'undefined' && /jsdom/i.test((navigator as any).userAgent || '')) return;

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import type VPixEngine from '../../../core/engine';
-import { COLOR_THEME } from '../../theme/colors';
+import { GRID_THEME } from '../../theme/colors';
 import './MiniMap.css';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
 
 export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, frame = 0 }: Props) {
   const ref = useRef<HTMLCanvasElement | null>(null);
-  const { canvasBackground, accent } = COLOR_THEME;
+  const { canvasBackground, accent } = GRID_THEME;
   useEffect(() => {
     // Skip drawing in jsdom test environment (no canvas impl)
     if (typeof navigator !== 'undefined' && /jsdom/i.test((navigator as any).userAgent || '')) return;

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,4 @@
-export const COLOR_THEME = {
+export const GRID_THEME = {
   canvasBackground: '#0b0b0b',
   accent: '#00e1ff',
   gridLine: 'rgba(255, 255, 255, 0.05)',


### PR DESCRIPTION
## Summary
- rename the grid color theme constant from COLOR_THEME to GRID_THEME
- update CanvasGrid and MiniMap components to consume GRID_THEME

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b891b0e48324878d60c971c05317