### PR TITLE
Enhance canvas commands and UI styling

### DIFF
--- a/core/commands/canvas.ts
+++ b/core/commands/canvas.ts
@@ -36,7 +36,7 @@ export const canvasCommands: CommandDefinition[] = [
     handler: ({ engine }, { size }) => {
       const dims = size as { w: number; h: number };
       engine.setSize(dims.w, dims.h);
-      return { msg: `${dims.w}×${dims.h}`, meta: { closeTerminal: true } };
+      return { msg: '', meta: { closeTerminal: true, silent: true } };
     },
     patterns: [{ pattern: 'set size {size:size}', help: 'set size <WxH>' }],
   },

--- a/core/commands/clipboard.ts
+++ b/core/commands/clipboard.ts
@@ -29,18 +29,18 @@ export const clipboardCommands: CommandDefinition[] = [
   },
   {
     id: 'selection.rotate-cw',
-    summary: 'Rotate clipboard clockwise',
+    summary: 'Rotate selection clockwise',
     handler: ({ engine }) => {
-      engine.rotateClipboardCW();
+      engine.rotateSelectionCW();
       return 'Rotated ↻';
     },
     patterns: [{ pattern: 'selection rotate-cw', help: 'selection rotate-cw' }],
   },
   {
     id: 'selection.rotate-ccw',
-    summary: 'Rotate clipboard counterclockwise',
+    summary: 'Rotate selection counterclockwise',
     handler: ({ engine }) => {
-      engine.rotateClipboardCCW();
+      engine.rotateSelectionCCW();
       return 'Rotated ↺';
     },
     patterns: [{ pattern: 'selection rotate-ccw', help: 'selection rotate-ccw' }],

--- a/core/commands/document.ts
+++ b/core/commands/document.ts
@@ -2,6 +2,37 @@ import VPixEngine from '../engine';
 
 import type { CommandDefinition } from './common';
 
+function normalizeHex(color: string): string | null {
+  let hex = color.trim();
+  if (hex.startsWith('#')) hex = hex.slice(1);
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map((ch) => ch + ch)
+      .join('');
+  }
+  if (hex.length !== 6) return null;
+  const value = Number.parseInt(hex, 16);
+  if (Number.isNaN(value)) return null;
+  return `#${hex.toUpperCase()}`;
+}
+
+function colorToRgba(color: string): [number, number, number, number] {
+  const normalized = normalizeHex(color);
+  if (!normalized) return [0, 0, 0, 255];
+  const hex = normalized.slice(1);
+  const value = Number.parseInt(hex, 16);
+  const r = (value >> 16) & 0xff;
+  const g = (value >> 8) & 0xff;
+  const b = value & 0xff;
+  return [r, g, b, 255];
+}
+
+function rgbaToHex(r: number, g: number, b: number): string {
+  const toHex = (component: number) => component.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+}
+
 export const documentCommands: CommandDefinition[] = [
   {
     id: 'document.read',
@@ -46,5 +77,178 @@ export const documentCommands: CommandDefinition[] = [
       }
     },
     patterns: [{ pattern: 'read url {url:url}', help: 'read url <https://...>' }],
+  },
+  {
+    id: 'document.export',
+    summary: 'Export current canvas as PNG',
+    handler: ({ engine }) => {
+      if (typeof document === 'undefined') return 'export unavailable';
+      const target = document.body;
+      if (!target) return 'export unavailable';
+
+      const canvas = document.createElement('canvas');
+      canvas.width = engine.width;
+      canvas.height = engine.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return 'export unavailable';
+
+      const imageData = ctx.createImageData(canvas.width, canvas.height);
+      const data = imageData.data;
+      for (let y = 0; y < engine.height; y += 1) {
+        for (let x = 0; x < engine.width; x += 1) {
+          const idx = (y * canvas.width + x) * 4;
+          const colorIndex = engine.grid[y][x];
+          if (colorIndex == null) {
+            data[idx] = 0;
+            data[idx + 1] = 0;
+            data[idx + 2] = 0;
+            data[idx + 3] = 0;
+            continue;
+          }
+          const color = engine.palette[colorIndex];
+          const [r, g, b, a] = colorToRgba(color ?? '#000000');
+          data[idx] = r;
+          data[idx + 1] = g;
+          data[idx + 2] = b;
+          data[idx + 3] = a;
+        }
+      }
+
+      ctx.putImageData(imageData, 0, 0);
+      const url = canvas.toDataURL('image/png');
+      const link = document.createElement('a');
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      link.download = `vpix-${timestamp}.png`;
+      link.href = url;
+      link.style.display = 'none';
+      target.appendChild(link);
+      try {
+        link.click();
+      } finally {
+        link.remove();
+      }
+
+      return { msg: `exported ${canvas.width}×${canvas.height}`, meta: { closeTerminal: true } };
+    },
+    patterns: [{ pattern: 'export', help: 'export' }],
+  },
+  {
+    id: 'document.import',
+    summary: 'Import PNG into canvas',
+    handler: ({ engine }) => {
+      if (typeof document === 'undefined') return 'import unavailable';
+      const target = document.body;
+      if (!target) return 'import unavailable';
+
+      return new Promise<string | { ok: boolean; msg: string; meta?: { closeTerminal?: boolean } }>((resolve) => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/png';
+        input.style.display = 'none';
+
+        const cleanup = () => {
+          input.remove();
+        };
+
+        input.addEventListener('change', () => {
+          const file = input.files?.[0];
+          if (!file) {
+            cleanup();
+            resolve({ ok: false, msg: 'import cancelled' });
+            return;
+          }
+
+          const reader = new FileReader();
+          reader.onerror = () => {
+            cleanup();
+            resolve({ ok: false, msg: 'import failed' });
+          };
+          reader.onload = () => {
+            const result = typeof reader.result === 'string' ? reader.result : '';
+            if (!result) {
+              cleanup();
+              resolve({ ok: false, msg: 'invalid image' });
+              return;
+            }
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => {
+              try {
+                const canvas = document.createElement('canvas');
+                canvas.width = img.width;
+                canvas.height = img.height;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) {
+                  cleanup();
+                  resolve({ ok: false, msg: 'import unavailable' });
+                  return;
+                }
+                ctx.drawImage(img, 0, 0);
+                const { data, width, height } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                const palette = engine.palette.slice();
+                const colorMap = new Map<string, number>();
+                palette.forEach((color, idx) => {
+                  const normalized = normalizeHex(color);
+                  if (normalized) colorMap.set(normalized, idx);
+                });
+                const grid = Array.from({ length: height }, (_, y) => {
+                  const row: Array<number | null> = [];
+                  for (let x = 0; x < width; x += 1) {
+                    const offset = (y * width + x) * 4;
+                    const alpha = data[offset + 3];
+                    if (alpha < 128) {
+                      row.push(null);
+                      continue;
+                    }
+                    const hex = normalizeHex(rgbaToHex(data[offset], data[offset + 1], data[offset + 2]));
+                    if (!hex) {
+                      row.push(null);
+                      continue;
+                    }
+                    let colorIndex = colorMap.get(hex);
+                    if (colorIndex == null) {
+                      if (palette.length >= 256) {
+                        colorIndex = 0;
+                      } else {
+                        palette.push(hex);
+                        colorIndex = palette.length - 1;
+                        colorMap.set(hex, colorIndex);
+                      }
+                    }
+                    row.push(colorIndex);
+                  }
+                  return row;
+                });
+
+                const snapshot = engine.toSnapshot();
+                snapshot.width = width;
+                snapshot.height = height;
+                snapshot.grid = grid;
+                snapshot.palette = palette;
+                const paletteCount = palette.length > 0 ? palette.length : 1;
+                snapshot.currentColorIndex = Math.min(snapshot.currentColorIndex, paletteCount - 1);
+                engine.loadSnapshot(snapshot);
+
+                cleanup();
+                resolve({ msg: `imported ${width}×${height}`, meta: { closeTerminal: true } });
+              } catch {
+                cleanup();
+                resolve({ ok: false, msg: 'import failed' });
+              }
+            };
+            img.onerror = () => {
+              cleanup();
+              resolve({ ok: false, msg: 'invalid image' });
+            };
+            img.src = result;
+          };
+          reader.readAsDataURL(file);
+        });
+
+        target.appendChild(input);
+        input.click();
+      });
+    },
+    patterns: [{ pattern: 'import', help: 'import' }],
   },
 ];

--- a/core/commands/mode.ts
+++ b/core/commands/mode.ts
@@ -152,6 +152,19 @@ export const modeCommands: CommandDefinition[] = [
     hidden: true,
   },
   {
+    id: 'operator.delete.line',
+    summary: 'Delete entire axis line',
+    handler: ({ engine }, { count }) => {
+      const times = ensureCount(count);
+      engine.deleteAxisLines(times);
+      engine.clearPendingOperator();
+      engine.clearPrefix();
+      return times > 1 ? `Deleted ${times} lines` : 'Deleted line';
+    },
+    patterns: [],
+    hidden: true,
+  },
+  {
     id: 'operator.change.to-end',
     summary: 'Change to line end respecting axis',
     handler: ({ engine }, { count }) => {

--- a/core/commands/selection.ts
+++ b/core/commands/selection.ts
@@ -169,10 +169,12 @@ export const selectionCommands: CommandDefinition[] = [
   },
   {
     id: 'selection.flood-fill',
-    summary: 'Flood fill selection area',
+    summary: 'Flood fill from cursor',
     handler: ({ engine }) => {
+      const sel = engine.selection;
+      const hadSelection = Boolean(sel?.active && sel?.rect);
       engine.floodFill(engine.cursor.x, engine.cursor.y);
-      engine.exitVisual();
+      if (hadSelection) engine.exitVisual();
       engine.clearPrefix();
       return 'Flood filled';
     },

--- a/core/keybindings.ts
+++ b/core/keybindings.ts
@@ -187,6 +187,14 @@ export const KEYBINDINGS: KeyBinding[] = [
   },
   {
     scope: 'normal',
+    key: 'f',
+    command: 'selection.flood-fill',
+    when: 'no-prefix',
+    description: 'Flood fill from cursor',
+    tips: ['Press f to bucket fill from cursor'],
+  },
+  {
+    scope: 'normal',
     key: 'p',
     command: 'clipboard.paste',
     when: 'no-prefix',

--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@
 .side-panel {
   width: 260px;
   background: var(--color-background);
-  border-left: 1px solid var(--color-border);
+  border-left: var(--border-width) solid var(--color-border);
   display: flex;
   flex-direction: column;
   padding: var(--spacing-l);
@@ -66,4 +66,34 @@
 
 .read-the-docs {
   color: var(--color-text-muted);
+}
+
+.vpix-command-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-background);
+  border-top: var(--border-width-strong) solid var(--color-accent);
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.vpix-command-prompt {
+  color: var(--color-accent);
+  font-family: monospace;
+  font-size: 1rem;
+}
+
+.vpix-command-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--color-text);
+  font-family: monospace;
+  font-size: 1rem;
 }

--- a/src/components/CanvasGrid/CanvasGrid.css
+++ b/src/components/CanvasGrid/CanvasGrid.css
@@ -13,13 +13,13 @@
 
 /* Axis indicator borders */
 .canvas-grid.axis-vertical .canvas-layer-stack {
-  border-left: 2px solid var(--color-accent);
-  border-right: 2px solid var(--color-accent);
+  border-left: var(--border-width-strong) solid var(--color-accent);
+  border-right: var(--border-width-strong) solid var(--color-accent);
 }
 
 .canvas-grid.axis-horizontal .canvas-layer-stack {
-  border-top: 2px solid var(--color-accent);
-  border-bottom: 2px solid var(--color-accent);
+  border-top: var(--border-width-strong) solid var(--color-accent);
+  border-bottom: var(--border-width-strong) solid var(--color-accent);
 }
 
 .canvas-layer-stack .canvas-base {

--- a/src/components/Grid/Grid.css
+++ b/src/components/Grid/Grid.css
@@ -9,9 +9,9 @@
   width: var(--spacing-l);
   height: var(--spacing-l);
   background: transparent;
-  outline: 1px solid var(--color-border);
+  outline: var(--border-width) solid var(--color-border);
 }
 .cell.cursor {
-  outline: 2px solid var(--color-accent);
+  outline: var(--border-width-strong) solid var(--color-accent);
   box-shadow: 0 0 6px rgba(0, 225, 255, 0.7);
 }

--- a/src/components/HelpModal/HelpModal.css
+++ b/src/components/HelpModal/HelpModal.css
@@ -11,7 +11,7 @@
 
 .help-modal {
   background: var(--color-background);
-  border: 2px solid var(--color-accent);
+  border: var(--border-width-strong) solid var(--color-accent);
   max-width: 800px;
   max-height: 80vh;
   width: 100%;
@@ -22,7 +22,7 @@
 
 .help-modal-header {
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -78,36 +78,72 @@
   letter-spacing: 0.05em;
 }
 
-.help-modal-commands {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.help-modal-table-wrapper {
+  overflow-x: auto;
 }
 
-.help-modal-command {
-  display: flex;
-  gap: 1rem;
+.help-modal-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.help-modal-table th,
+.help-modal-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: var(--border-width) solid var(--color-border);
+  vertical-align: top;
+}
+
+.help-modal-table th {
+  text-align: left;
+  color: var(--color-text);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.help-modal-table td:first-child {
   font-family: monospace;
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.help-modal-command-name {
   color: var(--color-accent);
-  min-width: 200px;
+  white-space: nowrap;
 }
 
-.help-modal-command-summary {
-  color: var(--color-text-dim);
-  flex: 1;
+.help-modal-table td:nth-child(2) {
+  color: var(--color-text-muted);
+}
+
+.help-modal-table td:last-child {
+  font-family: monospace;
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.help-modal-key-badge {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  margin: 0 0.25rem 0.25rem 0;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--spacing-xs);
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .help-modal-footer {
   padding: 1rem 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-width) solid var(--color-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.help-modal-footer a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.help-modal-footer a:hover {
+  text-decoration: underline;
 }
 
 .help-modal-checkbox-label {
@@ -116,9 +152,13 @@
   gap: 0.5rem;
   cursor: pointer;
   font-size: 0.9rem;
-  color: var(--color-text-dim);
+  color: var(--color-text-muted);
 }
 
 .help-modal-checkbox-label input {
   cursor: pointer;
+}
+
+.help-modal-no-keys {
+  color: var(--color-text-muted);
 }

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -76,19 +76,44 @@ export default function HelpModal({ onClose, onDontShowAgain }: Props) {
               <h3 className="help-modal-section-title">
                 {categoryNames[category] || category}
               </h3>
-              <div className="help-modal-commands">
-                {cmds.map((cmd) => (
-                  <div key={cmd.id} className="help-modal-command">
-                    <span className="help-modal-command-name">{cmd.name}</span>
-                    <span className="help-modal-command-summary">{cmd.summary}</span>
-                  </div>
-                ))}
+              <div className="help-modal-table-wrapper">
+                <table className="help-modal-table">
+                  <thead>
+                    <tr>
+                      <th>Command</th>
+                      <th>Summary</th>
+                      <th>Keys</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cmds.map((cmd) => (
+                      <tr key={cmd.id}>
+                        <td>{cmd.name}</td>
+                        <td>{cmd.summary}</td>
+                        <td>
+                          {cmd.keys.length ? (
+                            cmd.keys.map((key, idx) => (
+                              <span key={`${cmd.id}-key-${idx}`} className="help-modal-key-badge">
+                                {key}
+                              </span>
+                            ))
+                          ) : (
+                            <span className="help-modal-no-keys">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           ))}
         </div>
 
         <div className="help-modal-footer">
+          <a href="https://github.com/vpix/vpix2" target="_blank" rel="noreferrer">
+            GitHub’da proje sayfası
+          </a>
           <label className="help-modal-checkbox-label">
             <input
               type="checkbox"

--- a/src/components/Palette/Palette.css
+++ b/src/components/Palette/Palette.css
@@ -3,7 +3,7 @@
   gap: var(--spacing-s);
   padding: var(--spacing-s) var(--spacing-m);
   background: var(--color-background);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
 }
 .swatch {
   display: flex;
@@ -11,7 +11,7 @@
   gap: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-s);
   background: var(--color-background);
-  border: 1px solid var(--color-border);
+  border: var(--border-width) solid var(--color-border);
   border-radius: var(--spacing-xs);
   color: var(--color-text-muted);
 }
@@ -22,7 +22,7 @@
 .swatch .chip {
   width: 18px;
   height: 18px;
-  border: 1px solid var(--color-border);
+  border: var(--border-width) solid var(--color-border);
 }
 .swatch .key {
   opacity: 0.7;

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -1,6 +1,6 @@
 .status-bar {
   color: var(--color-text-muted);
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-width) solid var(--color-border);
 }
 .status-table {
   width: 100%;
@@ -19,12 +19,12 @@
 }
 .status-table tr + tr td,
 .status-table tr + tr th {
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-width) solid var(--color-border);
 }
 .color-chip {
   display: inline-block;
   width: 14px;
   height: 14px;
-  border: 1px solid var(--color-border);
+  border: var(--border-width) solid var(--color-border);
   vertical-align: middle;
 }

--- a/src/components/Terminal/Terminal.css
+++ b/src/components/Terminal/Terminal.css
@@ -4,7 +4,7 @@
   right: var(--spacing-m);
   bottom: var(--spacing-m);
   background: var(--color-background);
-  border: 1px solid var(--color-border);
+  border: var(--border-width) solid var(--color-border);
   border-radius: var(--spacing-s);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: var(--font-size-m);
@@ -22,7 +22,7 @@
   align-items: center;
   gap: var(--spacing-s);
   padding: var(--spacing-s) var(--spacing-m);
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-width) solid var(--color-border);
 }
 .prompt { color: var(--color-accent); }
 .term-input {

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,10 @@
   --color-text-muted: rgba(255, 255, 255, 0.4);
   --color-border: rgba(255, 255, 255, 0.1);
 
+  /* Border widths */
+  --border-width: 1px;
+  --border-width-strong: 2px;
+
   /* Font Boyutları */
   --font-size-s: 12px;
   --font-size-m: 14px;


### PR DESCRIPTION
## Summary
- standardize border widths with shared CSS variables and move the command bar styling into CSS for consistent visuals
- refresh the help modal with a key-aware table layout and add a direct GitHub link
- add PNG export/import commands and improve command handling for dd deletes, selection rotation, flood fill, and key matching
- ensure the canvas regains keyboard focus after dialogs and skip the onboarding modal during automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e57bb769488324b1f475b6f7aca544