### PR TITLE
Fix import palette handling and layout

### DIFF
--- a/core/commands/document.ts
+++ b/core/commands/document.ts
@@ -185,12 +185,23 @@ export const documentCommands: CommandDefinition[] = [
                 }
                 ctx.drawImage(img, 0, 0);
                 const { data, width, height } = ctx.getImageData(0, 0, canvas.width, canvas.height);
-                const palette = engine.palette.slice();
+                const originalPalette = engine.palette.slice();
+                const palette: string[] = [];
                 const colorMap = new Map<string, number>();
-                palette.forEach((color, idx) => {
-                  const normalized = normalizeHex(color);
-                  if (normalized) colorMap.set(normalized, idx);
-                });
+
+                const registerColor = (hex: string) => {
+                  const normalized = normalizeHex(hex);
+                  if (!normalized) return null;
+                  const existing = colorMap.get(normalized);
+                  if (existing != null) return existing;
+                  if (palette.length >= 256) {
+                    return palette.length > 0 ? 0 : null;
+                  }
+                  palette.push(normalized);
+                  const idx = palette.length - 1;
+                  colorMap.set(normalized, idx);
+                  return idx;
+                };
                 const grid = Array.from({ length: height }, (_, y) => {
                   const row: Array<number | null> = [];
                   for (let x = 0; x < width; x += 1) {
@@ -200,20 +211,11 @@ export const documentCommands: CommandDefinition[] = [
                       row.push(null);
                       continue;
                     }
-                    const hex = normalizeHex(rgbaToHex(data[offset], data[offset + 1], data[offset + 2]));
-                    if (!hex) {
+                    const hex = rgbaToHex(data[offset], data[offset + 1], data[offset + 2]);
+                    const colorIndex = registerColor(hex);
+                    if (colorIndex == null) {
                       row.push(null);
                       continue;
-                    }
-                    let colorIndex = colorMap.get(hex);
-                    if (colorIndex == null) {
-                      if (palette.length >= 256) {
-                        colorIndex = 0;
-                      } else {
-                        palette.push(hex);
-                        colorIndex = palette.length - 1;
-                        colorMap.set(hex, colorIndex);
-                      }
                     }
                     row.push(colorIndex);
                   }
@@ -224,9 +226,11 @@ export const documentCommands: CommandDefinition[] = [
                 snapshot.width = width;
                 snapshot.height = height;
                 snapshot.grid = grid;
-                snapshot.palette = palette;
-                const paletteCount = palette.length > 0 ? palette.length : 1;
-                snapshot.currentColorIndex = Math.min(snapshot.currentColorIndex, paletteCount - 1);
+                const nextPalette = palette.length > 0 ? palette : originalPalette;
+                snapshot.palette = nextPalette;
+                const paletteCount = Math.max(1, nextPalette.length);
+                snapshot.currentColorIndex = Math.min(snapshot.currentColorIndex ?? 0, paletteCount - 1);
+                if (snapshot.currentColorIndex < 0) snapshot.currentColorIndex = 0;
                 engine.loadSnapshot(snapshot);
 
                 cleanup();

--- a/src/components/Palette/Palette.css
+++ b/src/components/Palette/Palette.css
@@ -1,9 +1,15 @@
 .palette {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--spacing-s);
   padding: var(--spacing-s) var(--spacing-m);
   background: var(--color-background);
   border-bottom: var(--border-width) solid var(--color-border);
+  width: 100%;
+  box-sizing: border-box;
+  max-height: 200px;
+  overflow-y: auto;
+  align-content: flex-start;
 }
 .swatch {
   display: flex;


### PR DESCRIPTION
## Summary
- rebuild the document palette from imported PNG colors while clamping to 256 entries and keeping the current color index valid
- fall back to the previous palette when no opaque pixels are imported
- allow the palette bar to wrap and scroll so it no longer pushes the side panel off screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e586ed02b88324803379e10684a06d