### PR TITLE
Fix palette overflow when importing PNGs

### DIFF
--- a/src/components/Palette/Palette.css
+++ b/src/components/Palette/Palette.css
@@ -1,9 +1,12 @@
 .palette {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--spacing-s);
   padding: var(--spacing-s) var(--spacing-m);
   background: var(--color-background);
   border-bottom: var(--border-width) solid var(--color-border);
+  width: 100%;
+  box-sizing: border-box;
 }
 .swatch {
   display: flex;


### PR DESCRIPTION
## Summary
- allow the palette toolbar to wrap so large imports do not push the sidebar off screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58dfe0d808324b6dac3c58157a7a0