### PR TITLE
Improve zoom scaling and make canvas responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,6 +19,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .side-panel {

--- a/src/components/CanvasGrid/CanvasGrid.css
+++ b/src/components/CanvasGrid/CanvasGrid.css
@@ -1,14 +1,17 @@
 .canvas-grid {
   flex: 1;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: stretch;
   background: var(--color-background);
   box-sizing: border-box;
+  min-height: 0;
 }
 .canvas-layer-stack {
   position: relative;
   line-height: 0;
+  width: 100%;
+  height: 100%;
 }
 
 /* Axis indicator borders */
@@ -22,18 +25,21 @@
   border-bottom: var(--border-width-strong) solid var(--color-accent);
 }
 
-.canvas-layer-stack .canvas-base {
-  display: block;
-  image-rendering: pixelated;
-  background: var(--color-background);
-}
-
+.canvas-layer-stack .canvas-base,
 .canvas-layer-stack .canvas-overlay {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   image-rendering: pixelated;
+}
+
+.canvas-layer-stack .canvas-base {
+  display: block;
+  background: var(--color-background);
+}
+
+.canvas-layer-stack .canvas-overlay {
   pointer-events: none;
   background: transparent;
 }

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -11,9 +11,18 @@ type Props = {
   viewW?: number;
   viewH?: number;
   frame?: number;
+  cellSize?: number;
 };
 
-export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, frame = 0 }: Props) {
+export default function MiniMap({
+  engine,
+  pan,
+  zoom,
+  viewW = 800,
+  viewH = 480,
+  frame = 0,
+  cellSize,
+}: Props) {
   const ref = useRef<HTMLCanvasElement | null>(null);
   const { canvasBackground, accent } = GRID_THEME;
   useEffect(() => {
@@ -50,7 +59,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
       for (let x = 0; x < engine.width; x++) drawCell(x, y);
     }
     // viewport rectangle
-    const cellPx = 16 * (zoom || 1);
+    const cellPx = Math.max(1, cellSize || Math.round(16 * (zoom || 1)));
     const visWcells = Math.max(1, Math.floor(viewW / cellPx));
     const visHcells = Math.max(1, Math.floor(viewH / cellPx));
     const rx = Math.max(0, Math.min(engine.width, (pan?.x || 0))) * cell;
@@ -60,7 +69,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
     ctx.strokeStyle = accent;
     ctx.lineWidth = 2;
     ctx.strokeRect(rx + 0.5, ry + 0.5, rw, rh);
-  }, [engine, pan, zoom, viewW, viewH, frame]);
+  }, [engine, pan, zoom, viewW, viewH, frame, cellSize]);
 
   return (
     <div className="minimap">


### PR DESCRIPTION
## Summary
- resize the canvas stack with a ResizeObserver so it fills the available workspace and shares its live dimensions with the app
- derive the base cell size from the current viewport to keep zoom levels intuitive and clamp the minimum zoom dynamically
- update the minimap viewport logic to use the shared cell size so its window matches the main canvas

## Testing
- npm test -- --watch=false
- npm run lint (fails: existing lint warnings/errors in untouched files)


------
https://chatgpt.com/codex/tasks/task_e_68e5933413188324a66ae698f37b1a44