### PR TITLE
Improve zoom scaling and make canvas responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,6 +19,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .side-panel {

--- a/src/components/CanvasGrid/CanvasGrid.css
+++ b/src/components/CanvasGrid/CanvasGrid.css
@@ -1,14 +1,17 @@
 .canvas-grid {
   flex: 1;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: stretch;
   background: var(--color-background);
   box-sizing: border-box;
+  min-height: 0;
 }
 .canvas-layer-stack {
   position: relative;
   line-height: 0;
+  width: 100%;
+  height: 100%;
 }
 
 /* Axis indicator borders */
@@ -22,18 +25,21 @@
   border-bottom: var(--border-width-strong) solid var(--color-accent);
 }
 
-.canvas-layer-stack .canvas-base {
-  display: block;
-  image-rendering: pixelated;
-  background: var(--color-background);
-}
-
+.canvas-layer-stack .canvas-base,
 .canvas-layer-stack .canvas-overlay {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   image-rendering: pixelated;
+}
+
+.canvas-layer-stack .canvas-base {
+  display: block;
+  background: var(--color-background);
+}
+
+.canvas-layer-stack .canvas-overlay {
   pointer-events: none;
   background: transparent;
 }

--- a/src/components/CanvasGrid/CanvasGrid.tsx
+++ b/src/components/CanvasGrid/CanvasGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type VPixEngine from '../../../core/engine';
 import { GRID_THEME } from '../../theme/colors';
@@ -10,18 +10,83 @@ type Props = {
   pan?: { x: number; y: number };
   frame?: number;
   trail?: Array<{ x: number; y: number; ts: number }>;
+  cellSize: number;
+  onViewSizeChange?: (size: { width: number; height: number }) => void;
 };
 
-export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, frame = 0, trail = [] }: Props) {
+export default function CanvasGrid({
+  engine,
+  zoom = 1,
+  pan = { x: 0, y: 0 },
+  frame = 0,
+  trail = [],
+  cellSize,
+  onViewSizeChange,
+}: Props) {
   const baseRef = useRef<HTMLCanvasElement | null>(null);
   const overlayRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [viewDimensions, setViewDimensions] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
   const panX = pan?.x ?? 0;
   const panY = pan?.y ?? 0;
-  const cellSize = useMemo(() => Math.max(1, Math.floor(16 * (zoom || 1))), [zoom]);
+  const showGridLines = (zoom || 1) > 2;
   const axis = engine.axis;
   const axisClass = axis === 'vertical' ? 'axis-vertical' : 'axis-horizontal';
   const gridClassName = `canvas-grid ${axisClass}`;
   const { canvasBackground, gridLine, accent, cursorHighlight } = GRID_THEME;
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    let lastWidth = 0;
+    let lastHeight = 0;
+    const applySize = (width: number, height: number) => {
+      const targetWidth = Math.max(1, Math.floor(width));
+      const targetHeight = Math.max(1, Math.floor(height));
+      if (targetWidth === lastWidth && targetHeight === lastHeight) return;
+      lastWidth = targetWidth;
+      lastHeight = targetHeight;
+      const baseCanvas = baseRef.current;
+      const overlayCanvas = overlayRef.current;
+      if (baseCanvas) {
+        if (baseCanvas.width !== targetWidth) baseCanvas.width = targetWidth;
+        if (baseCanvas.height !== targetHeight) baseCanvas.height = targetHeight;
+      }
+      if (overlayCanvas) {
+        if (overlayCanvas.width !== targetWidth) overlayCanvas.width = targetWidth;
+        if (overlayCanvas.height !== targetHeight) overlayCanvas.height = targetHeight;
+      }
+      setViewDimensions((prev) => {
+        if (prev.width === targetWidth && prev.height === targetHeight) return prev;
+        return { width: targetWidth, height: targetHeight };
+      });
+      if (onViewSizeChange) {
+        onViewSizeChange({ width: targetWidth, height: targetHeight });
+      }
+    };
+
+    if (typeof ResizeObserver === 'undefined') {
+      applySize(wrapper.clientWidth, wrapper.clientHeight);
+      return;
+    }
+
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        applySize(width, height);
+      }
+    });
+    applySize(wrapper.clientWidth, wrapper.clientHeight);
+    ro.observe(wrapper);
+    return () => {
+      ro.disconnect();
+    };
+  }, [onViewSizeChange]);
+
+  const { width: viewWidth, height: viewHeight } = viewDimensions;
 
   useEffect(() => {
     if (typeof navigator !== 'undefined' && /jsdom/i.test((navigator as any).userAgent || '')) return;
@@ -38,8 +103,8 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     if (!ctx) return;
 
     const cell = cellSize;
-    const viewW = canvas.width;
-    const viewH = canvas.height;
+    const viewW = viewWidth || canvas.width;
+    const viewH = viewHeight || canvas.height;
     const offsetX = -panX * cell;
     const offsetY = -panY * cell;
 
@@ -65,7 +130,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     for (let y = 0; y < engine.height; y++) {
       for (let x = 0; x < engine.width; x++) drawCell(x, y);
     }
-  }, [cellSize, engine, panX, panY, frame]);
+  }, [cellSize, engine, panX, panY, frame, viewHeight, viewWidth]);
 
   // Single rAF loop to redraw overlay each frame (selection, trail, cursor)
   useEffect(() => {
@@ -94,7 +159,7 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
       const clipTop = Math.max(0, Math.floor(gridTop));
       const clipBottom = Math.min(viewH, Math.ceil(gridBottom));
 
-      if (clipRight > clipLeft && clipBottom > clipTop) {
+      if (showGridLines && clipRight > clipLeft && clipBottom > clipTop) {
         ctx.strokeStyle = gridLine;
         ctx.lineWidth = 1;
         for (let x = 0; x <= engine.width; x++) {
@@ -170,10 +235,10 @@ export default function CanvasGrid({ engine, zoom = 1, pan = { x: 0, y: 0 }, fra
     };
     rafId = requestAnimationFrame(draw);
     return () => cancelAnimationFrame(rafId);
-  }, [cellSize, engine, panX, panY, trail]);
+  }, [cellSize, engine, panX, panY, showGridLines, trail]);
 
   return (
-    <div className={gridClassName}>
+    <div className={gridClassName} ref={wrapperRef}>
       <div className="canvas-layer-stack">
         <canvas ref={baseRef} className="canvas-base" width={800} height={480} />
         <canvas ref={overlayRef} className="canvas-overlay" width={800} height={480} />

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -11,9 +11,18 @@ type Props = {
   viewW?: number;
   viewH?: number;
   frame?: number;
+  cellSize?: number;
 };
 
-export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, frame = 0 }: Props) {
+export default function MiniMap({
+  engine,
+  pan,
+  zoom,
+  viewW = 800,
+  viewH = 480,
+  frame = 0,
+  cellSize,
+}: Props) {
   const ref = useRef<HTMLCanvasElement | null>(null);
   const { canvasBackground, accent } = GRID_THEME;
   useEffect(() => {
@@ -50,7 +59,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
       for (let x = 0; x < engine.width; x++) drawCell(x, y);
     }
     // viewport rectangle
-    const cellPx = 16 * (zoom || 1);
+    const cellPx = Math.max(1, cellSize || Math.round(16 * (zoom || 1)));
     const visWcells = Math.max(1, Math.floor(viewW / cellPx));
     const visHcells = Math.max(1, Math.floor(viewH / cellPx));
     const rx = Math.max(0, Math.min(engine.width, (pan?.x || 0))) * cell;
@@ -60,7 +69,7 @@ export default function MiniMap({ engine, pan, zoom, viewW = 800, viewH = 480, f
     ctx.strokeStyle = accent;
     ctx.lineWidth = 2;
     ctx.strokeRect(rx + 0.5, ry + 0.5, rw, rh);
-  }, [engine, pan, zoom, viewW, viewH, frame]);
+  }, [engine, pan, zoom, viewW, viewH, frame, cellSize]);
 
   return (
     <div className="minimap">


### PR DESCRIPTION
## Summary
- resize the canvas stack with a ResizeObserver so it fills the available workspace and shares its live dimensions with the app
- derive the base cell size from the current viewport to keep zoom levels intuitive and clamp the minimum zoom dynamically
- update the minimap viewport logic to use the shared cell size so its window matches the main canvas
- trigger a base-layer redraw whenever resize events change the view dimensions so the canvas never appears blank after resizing

## Testing
- npm test -- --watch=false
- npm run lint (fails: existing lint warnings/errors in untouched files)

------
https://chatgpt.com/codex/tasks/task_e_68e5933413188324a66ae698f37b1a44