### PR TITLE
Enforce canonical keybindings for Zen rule

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -69,6 +69,12 @@ Bu manifesto, VPix (Vim‑benzeri piksel editörü) için karar alma pusulasıd�
 - Link (vp2r), sürüm meta’sı ve palette slug ile eserin temsilini sabitler.
 - İleride: checksum/manifest ekleri; farklı ortamda uyarı, mümkünse uyumlu açılım.
 
+## 17. Tek Yol İlkesi (The One Way Rule)
+- Python’un “There should be one—and preferably only one—obvious way to do it” prensibinden ilham alır; her eylemin açık, tek ve sezgisel bir yolu olmalıdır.
+- Her işlev yalnızca bir tuş veya komutla çağrılabilir; kullanıcı aynı sonucu almak için yollar arasında seçim yapmak zorunda kalmamalıdır.
+- Aynı işi yapan alternatif kısayollar ya da alias’lar yalnızca geçici uyumluluk amacıyla tutulur; aksi durumda sistemin içsel tutarlılığını zayıflatır.
+- Bu ilke, öğrenme eğrisini kısaltır, kas hafızasını güçlendirir, belirsizlikleri ortadan kaldırır ve kullanıcıyı araçla değil yaratım süreciyle baş başa bırakır.
+
 ---
 
 # İkilem Anında Yol Haritası

--- a/core/commands/share.ts
+++ b/core/commands/share.ts
@@ -10,13 +10,4 @@ export const shareCommands: CommandDefinition[] = [
     },
     patterns: [{ pattern: 'link', help: 'link' }],
   },
-  {
-    id: 'share.copylink',
-    summary: 'Copy shareable link to clipboard',
-    handler: async ({ engine, services }) => {
-      const res = await services.shareLinks.copyLink(engine);
-      return res.msg;
-    },
-    patterns: [{ pattern: 'copylink', help: 'copylink' }],
-  },
 ];

--- a/core/keybindings.ts
+++ b/core/keybindings.ts
@@ -40,16 +40,15 @@ export const KEYBINDINGS: KeyBinding[] = [
   },
 
   // Global bindings
-  { scope: 'global', key: 'ctrl+z', command: 'history.undo', description: 'Undo last action' },
+  // Aliases removed for Zen: [ctrl+y]
   {
     scope: 'global',
-    key: 'ctrl+y',
+    key: 'ctrl+r',
     command: 'history.redo',
     description: 'Redo last action',
     tips: ['Press Ctrl+r to redo'],
   },
-  { scope: 'global', key: 'ctrl+r', command: 'history.redo', description: 'Redo last action' },
-  { scope: 'global', key: 'ctrl+6', command: 'palette.swap-last-color', description: 'Swap to last used color' },
+  // Aliases removed for Zen: [ctrl+6]
   { scope: 'global', key: 'ctrl+^', command: 'palette.swap-last-color', description: 'Swap to last used color' },
   {
     scope: 'global',
@@ -225,6 +224,7 @@ export const KEYBINDINGS: KeyBinding[] = [
     description: 'Paste at cursor (transparent)',
     tips: ['Press P to paste transparent (skip empty)'],
   },
+  // Aliases removed for Zen: [ctrl+z]
   {
     scope: 'normal',
     key: 'u',
@@ -372,8 +372,8 @@ export const KEYBINDINGS: KeyBinding[] = [
     description: 'Expand selection to the right',
   },
   { scope: 'visual', key: 'y', command: 'selection.yank', description: 'Yank selection' },
+  // Aliases removed for Zen: [x]
   { scope: 'visual', key: 'd', command: 'selection.delete', description: 'Delete selection (cut)' },
-  { scope: 'visual', key: 'x', command: 'selection.delete', description: 'Delete selection (cut)' },
   { scope: 'visual', key: 'p', command: 'selection.paste', description: 'Paste at cursor' },
   { scope: 'visual', key: 'shift+p', command: 'selection.paste-transparent', description: 'Paste (transparent)' },
   {

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -7,10 +7,8 @@
 
 | Shortcut | When | Command | Description |
 | --- | --- | --- | --- |
-| `ctrl+z` | Always | `history.undo` | Undo last action |
-| `ctrl+y` | Always | `history.redo` | Redo last action |
+| `__general__` | Always | `noop` | General tips |
 | `ctrl+r` | Always | `history.redo` | Redo last action |
-| `ctrl+6` | Always | `palette.swap-last-color` | Swap to last used color |
 | `ctrl+^` | Always | `palette.swap-last-color` | Swap to last used color |
 | `Tab` | Always | `axis.toggle` | Toggle axis (horizontal/vertical) |
 
@@ -28,14 +26,15 @@
 | `0` | No prefix | `motion.line-begin` | Go to axis line begin |
 | `^` | No prefix | `motion.line-first-nonblank` | Go to first non-empty cell on axis line |
 | `$` | No prefix | `motion.line-end` | Go to axis line end |
-| `G` | No prefix | `motion.canvas-end` | Go to canvas end |
+| `shift+g` | No prefix | `motion.canvas-end` | Go to canvas end |
 | `x` | No prefix | `paint.cut` | Cut cell(s) (delete and yank) |
 | `d` | No prefix | `operator.set` | Begin delete operator |
 | `y` | No prefix | `operator.set` | Begin yank operator |
 | ` ` | No prefix | `paint.toggle` | Toggle cell(s) |
+| `f` | No prefix | `selection.flood-fill` | Flood fill from cursor |
 | `p` | No prefix | `clipboard.paste` | Paste at cursor |
-| `D` | No prefix | `operator.delete.to-end` | Delete to line end |
-| `C` | No prefix | `operator.change.to-end` | Change to line end |
+| `shift+d` | No prefix | `operator.delete.to-end` | Delete to line end |
+| `shift+c` | No prefix | `operator.change.to-end` | Change to line end |
 | `P` | No prefix | `clipboard.paste-transparent` | Paste at cursor (transparent) |
 | `u` | No prefix | `history.undo` | Undo last action |
 | `.` | No prefix | `edit.repeat-last` | Repeat last change |
@@ -48,7 +47,7 @@
 | `e` | After `g` prefix | `motion.word-end-prev` | Move to previous run end |
 | `Escape` | Prefix active | `prefix.clear` | Cancel pending prefix |
 | `t` | After `g` prefix | `palette.cycle-next` | Cycle to next palette color |
-| `T` | After `g` prefix | `palette.cycle-previous` | Cycle to previous palette color |
+| `shift+t` | After `g` prefix | `palette.cycle-previous` | Cycle to previous palette color |
 | `1..9` | After `r` prefix | `palette.paint-color` | Paint using palette color by index |
 
 ## Visual mode
@@ -62,15 +61,14 @@
 | `l` | Always | `selection.move-right` | Expand selection to the right |
 | `y` | Always | `selection.yank` | Yank selection |
 | `d` | Always | `selection.delete` | Delete selection (cut) |
-| `x` | Always | `selection.delete` | Delete selection (cut) |
 | `p` | Always | `selection.paste` | Paste at cursor |
-| `P` | Always | `selection.paste-transparent` | Paste (transparent) |
+| `shift+p` | Always | `selection.paste-transparent` | Paste (transparent) |
 | `]` | Always | `selection.rotate-cw` | Rotate clipboard clockwise |
 | `[` | Always | `selection.rotate-ccw` | Rotate clipboard counterclockwise |
-| `M` | Always | `selection.move-to-cursor` | Move selection to cursor |
-| `F` | Always | `selection.fill` | Fill selection |
-| `R` | Always | `selection.stroke-rect` | Stroke selection rectangle |
-| `C` | Always | `selection.stroke-circle` | Stroke selection circle |
-| `O` | Always | `selection.fill-circle` | Fill selection circle |
-| `L` | Always | `selection.draw-line` | Draw line across selection |
+| `shift+m` | Always | `selection.move-to-cursor` | Move selection to cursor |
+| `shift+f` | Always | `selection.fill` | Fill selection |
+| `shift+r` | Always | `selection.stroke-rect` | Stroke selection rectangle |
+| `shift+c` | Always | `selection.stroke-circle` | Stroke selection circle |
+| `shift+o` | Always | `selection.fill-circle` | Fill selection circle |
+| `shift+l` | Always | `selection.draw-line` | Draw line across selection |
 | `f` | Always | `selection.flood-fill` | Flood fill selection |

--- a/test/engine.spec.ts
+++ b/test/engine.spec.ts
@@ -93,13 +93,13 @@ describe('VPixEngine', () => {
     assert.equal(eng.currentColorIndex, start);
   });
 
-  it('Ctrl-^ toggles last color (Ctrl+6)', () => {
+  it('Ctrl-^ toggles last color', () => {
     const eng = new VPixEngine({ width: 2, height: 2, palette: pico.colors });
     eng.setColorIndex(4);
     eng.setColorIndex(1);
-    eng.handleKey({ key: '6', ctrlKey: true });
+    eng.handleKey({ key: '^', ctrlKey: true, shiftKey: true });
     assert.equal(eng.currentColorIndex, 4);
-    eng.handleKey({ key: '6', ctrlKey: true });
+    eng.handleKey({ key: '^', ctrlKey: true, shiftKey: true });
     assert.equal(eng.currentColorIndex, 1);
   });
 


### PR DESCRIPTION
## Summary
- remove redundant keybinding aliases and annotate survivors with Zen alias removal notes
- regenerate the key reference and update engine tests for the canonical shortcuts
- drop the :copylink command so :link is the single share entry point

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6785f89ec8324946d579254ed5a26